### PR TITLE
Trigger revision

### DIFF
--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/RoboChart.xtext
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/RoboChart.xtext
@@ -275,9 +275,10 @@ Transition:
 		'from' source=[Node]
 		'to' target=[Node]
 		(
-			'trigger' trigger=Trigger ('<{' end=Expression '}')? |
+			'trigger' trigger=Communication |
 			'probability' probability=Expression
 		)?
+		(reset+=ClockReset)* ('<{' deadline=Expression '}')?
 		('condition' condition=(Expression|Else))?
 		('action' action=Statement)?
 	'}'
@@ -291,12 +292,7 @@ Clock:
 	'clock' name=ID 
 ;
 
-Trigger: (ActualTrigger | EmptyTrigger) 
-	('@' time=[Variable])?
-	( reset+=ClockReset)*
-;
-
-ActualTrigger returns Trigger:
+Communication returns Communication:
 	event=[Event] 
 	(
 		'[|' 
@@ -316,20 +312,16 @@ ActualTrigger returns Trigger:
 	)?
 ;
 
-enum InputType returns TriggerType:
+enum InputType returns CommunicationType:
 	INPUT = '?'
 ;
 
-enum OutputType returns TriggerType:
+enum OutputType returns CommunicationType:
 	OUTPUT = '!'
 ;
 
-enum SyncType returns TriggerType:
+enum SyncType returns CommunicationType:
 	SYNC = '.'
-;
-
-EmptyTrigger returns Trigger:
-	{Trigger}
 ;
 
 Action:
@@ -569,12 +561,12 @@ Statement:
 //;
 
 EndStatement returns Statement:
-	BasicStatement ({TimedStatement.stmt=current} '<{' end=Expression '}')?
+	BasicStatement ({TimedStatement.stmt=current} '<{' deadline=Expression '}')?
 ;
 
 BasicStatement returns Statement:
 	IfStmt |
-	SendEvent |
+	CommunicationStmt |
 	Skip |
 	Call |
 	Assignment |
@@ -614,8 +606,8 @@ VariableReference returns Assignable:
 	{VarRef} name=[Variable|QualifiedName]
 ;
 
-SendEvent:
-	('send')? trigger=ActualTrigger
+CommunicationStmt:
+	('send')? communication=Communication
 ;
 
 RCModule:

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
@@ -51,14 +51,14 @@ import circus.robocalc.robochart.RefExp
 import circus.robocalc.robochart.RoboticPlatformDef
 import circus.robocalc.robochart.RoboticPlatformRef
 import circus.robocalc.robochart.Selection
-import circus.robocalc.robochart.SendEvent
+import circus.robocalc.robochart.CommunicationStmt
 import circus.robocalc.robochart.SetComp
 import circus.robocalc.robochart.State
 import circus.robocalc.robochart.StateClockExp
 import circus.robocalc.robochart.StateMachineDef
 import circus.robocalc.robochart.StateMachineRef
 import circus.robocalc.robochart.Transition
-import circus.robocalc.robochart.Trigger
+import circus.robocalc.robochart.Communication
 import circus.robocalc.robochart.Type
 import circus.robocalc.robochart.TypeDecl
 import circus.robocalc.robochart.TypeRef
@@ -100,10 +100,10 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 	override getScope(EObject context, EReference reference) {
 		if (context instanceof Connection) {
 			return context.getScopeForConnection(reference)
-		} else if (context instanceof Trigger) {
-			return context.getTriggerScope(reference)
-		} else if (context instanceof SendEvent) {
-			return context.getSendEventScope(reference)
+		} else if (context instanceof Communication) {
+			return context.getCommunicationScope(reference)
+		} else if (context instanceof CommunicationStmt) {
+			return context.getCommunicationStmtScope(reference)
 		} else if (context instanceof Selection) {
 			if (reference === SELECTION__MEMBER) {
 				val s = getSelectionScope(context.receiver.typeFor)
@@ -405,8 +405,8 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 			return parentScope
 	}
 
-	def getTriggerScope(Trigger context, EReference reference) {
-		if (reference === TRIGGER__EVENT) {
+	def getCommunicationScope(Communication context, EReference reference) {
+		if (reference === COMMUNICATION__EVENT) {
 			var o = context.eContainer
 			val result = delegateGetScope(context, reference)
 			// while (!(o instanceof StateMachineDef || o === null)) {
@@ -414,13 +414,13 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 			// }
 			// (o as StateMachineDef).eventsDeclared
 			return o.eventsDeclared(result)
-		} else if (reference === TRIGGER__TIME) {
-			val result = delegateGetScope(context, reference)
-			return context.eContainer.variablesDeclared(result)
-		} else if (context instanceof Trigger && reference === TRIGGER__PARAMETER) {
+//		} else if (reference === TRIGGER__TIME) {
+//			val result = delegateGetScope(context, reference)
+//			return context.eContainer.variablesDeclared(result)
+		} else if (context instanceof Communication && reference === COMMUNICATION__PARAMETER) {
 			val result = delegateGetScope(context, reference)
 			return context.variablesDeclared(result)
-		} else if (context instanceof Trigger && reference === TRIGGER__FROM) {
+		} else if (context instanceof Communication && reference === COMMUNICATION__FROM) {
 			val result = delegateGetScope(context, reference)
 			return context.variablesDeclared(result)
 		} else {
@@ -429,8 +429,8 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 	}
 
 	// don't think I need this
-	def getSendEventScope(SendEvent context, EReference reference) {
-		if (reference === SEND_EVENT__TRIGGER) {
+	def getCommunicationStmtScope(CommunicationStmt context, EReference reference) {
+		if (reference === COMMUNICATION_STMT__COMMUNICATION) {
 			var o = context.eContainer
 			val result = delegateGetScope(context, reference)
 			/*while (!(o instanceof StateMachineDef || o === null)) {
@@ -806,7 +806,7 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 		return s
 	}
 
-	def dispatch IScope clocksDeclared(Trigger cont) {
+	def dispatch IScope clocksDeclared(Communication cont) {
 		cont.eContainer.clocksDeclared();
 	}
 	

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -85,7 +85,6 @@ import circus.robocalc.robochart.RoboChartPackage
 import circus.robocalc.robochart.RoboticPlatform
 import circus.robocalc.robochart.RoboticPlatformDef
 import circus.robocalc.robochart.RoboticPlatformRef
-import circus.robocalc.robochart.SendEvent
 import circus.robocalc.robochart.SeqExp
 import circus.robocalc.robochart.SeqStatement
 import circus.robocalc.robochart.SetComp
@@ -127,6 +126,7 @@ import org.eclipse.xtext.validation.CheckType
 import java.util.ArrayList
 import circus.robocalc.robochart.Clock
 import circus.robocalc.robochart.Communication
+import circus.robocalc.robochart.CommunicationStmt
 
 /**
  * This class contains custom validation rules. 
@@ -504,7 +504,7 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 
 	def outputEvents(StateMachineBody stm) {
 		val output = new HashSet<Event>()
-		stm.eAllContents.filter(SendEvent).forEach[s|output.add(s.trigger?.event)]
+		stm.eAllContents.filter(CommunicationStmt).forEach[s|output.add(s.communication?.event)]
 		output
 	}
 
@@ -1883,17 +1883,17 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		}
 	}
 
-	@Check
-	def sendEventWFC(SendEvent s) {
-//		if (s.trigger.reset !== null && s.trigger.reset.length > 0) {
-//			error('A send action cannot have a reset associated with it', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
-//				'NoResetInSendEvent');
-//		}
-//		if (s.trigger._type === CommunicationType.EMPTY) {
-//			error('A send action cannot have an empty trigger', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
-//				'NoEmptyTriggerInSendEvent');
-//		}
-	}
+//	@Check
+//	def sendEventWFC(SendEvent s) {
+////		if (s.trigger.reset !== null && s.trigger.reset.length > 0) {
+////			error('A send action cannot have a reset associated with it', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
+////				'NoResetInSendEvent');
+////		}
+////		if (s.trigger._type === CommunicationType.EMPTY) {
+////			error('A send action cannot have an empty trigger', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
+////				'NoEmptyTriggerInSendEvent');
+////		}
+//	}
 
 	@Check
 	def communicationWellTyped(Communication t) {
@@ -2260,14 +2260,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	def HashSet<Event> statementOutputSet(Statement s) {
 		var outputs = new HashSet<Event>()
 
-		if (s instanceof SendEvent) {
-			if (s.trigger !== null && s.trigger.get_type === CommunicationType.OUTPUT)
-				outputs.add(s.trigger.event)
-			if (s.trigger !== null && s.trigger.get_type === CommunicationType.SYNC)
-				outputs.add(s.trigger.event) // c.x is an output
+		if (s instanceof CommunicationStmt) {
+			if (s.communication !== null && s.communication.get_type === CommunicationType.OUTPUT)
+				outputs.add(s.communication.event)
+			if (s.communication !== null && s.communication.get_type === CommunicationType.SYNC)
+				outputs.add(s.communication.event) // c.x is an output
 				// simple event in statement is always an output
-			if (s.trigger !== null && s.trigger.get_type === CommunicationType.SIMPLE)
-				outputs.add(s.trigger.event)
+			if (s.communication !== null && s.communication.get_type === CommunicationType.SIMPLE)
+				outputs.add(s.communication.event)
 		} else if (s instanceof SeqStatement) {
 			for (s2 : s.statements) {
 				outputs.addAll(statementOutputSet(s2))
@@ -2312,9 +2312,9 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	def HashSet<Event> statementInputSet(Statement s) {
 		var inputs = new HashSet<Event>()
 
-		if (s instanceof SendEvent) {
-			if (s.trigger !== null && s.trigger.get_type === CommunicationType.INPUT)
-				inputs.add(s.trigger.event)
+		if (s instanceof CommunicationStmt) {
+			if (s.communication !== null && s.communication.get_type === CommunicationType.INPUT)
+				inputs.add(s.communication.event)
 		} else if (s instanceof SeqStatement) {
 			for (s2 : s.statements) {
 				inputs.addAll(statementInputSet(s2))

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -97,8 +97,7 @@ import circus.robocalc.robochart.StateMachineDef
 import circus.robocalc.robochart.StateMachineRef
 import circus.robocalc.robochart.Statement
 import circus.robocalc.robochart.Transition
-import circus.robocalc.robochart.Trigger
-import circus.robocalc.robochart.TriggerType
+import circus.robocalc.robochart.CommunicationType
 import circus.robocalc.robochart.TupleExp
 import circus.robocalc.robochart.Type
 import circus.robocalc.robochart.TypeRef
@@ -127,6 +126,7 @@ import org.eclipse.xtext.validation.Check
 import org.eclipse.xtext.validation.CheckType
 import java.util.ArrayList
 import circus.robocalc.robochart.Clock
+import circus.robocalc.robochart.Communication
 
 /**
  * This class contains custom validation rules. 
@@ -1885,121 +1885,117 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 
 	@Check
 	def sendEventWFC(SendEvent s) {
-		if (s.trigger.time !== null) {
-			error('A send action cannot have a time associated with it', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
-				'NoTimeInSendEvent');
-		}
-		if (s.trigger.reset !== null && s.trigger.reset.length > 0) {
-			error('A send action cannot have a reset associated with it', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
-				'NoResetInSendEvent');
-		}
-		if (s.trigger._type === TriggerType.EMPTY) {
-			error('A send action cannot have an empty trigger', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
-				'NoEmptyTriggerInSendEvent');
-		}
+//		if (s.trigger.reset !== null && s.trigger.reset.length > 0) {
+//			error('A send action cannot have a reset associated with it', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
+//				'NoResetInSendEvent');
+//		}
+//		if (s.trigger._type === CommunicationType.EMPTY) {
+//			error('A send action cannot have an empty trigger', RoboChartPackage.Literals.SEND_EVENT__TRIGGER,
+//				'NoEmptyTriggerInSendEvent');
+//		}
 	}
 
 	@Check
-	def triggerWellTyped(Trigger t) {
+	def communicationWellTyped(Communication t) {
 		/* Tg1 */
 		// Violation is currently not possible because the syntax (editors) doesn't allow the creation of such objects
-		if (t._type === TriggerType.SIMPLE) {
+		if (t._type === CommunicationType.SIMPLE) {
 			if (t.parameter !== null) {
 				error(
-					'A simple trigger should not specify a parameter attribute',
-					RoboChartPackage.Literals.TRIGGER__PARAMETER,
+					'A simple communication should not specify a parameter attribute',
+					RoboChartPackage.Literals.COMMUNICATION__PARAMETER,
 					'NoParametersForSimpleTriggers'
 				)							
 			}
 			if (t.value !== null) {
 				error(
-					'A simple trigger should not specify a value attribute',
-					RoboChartPackage.Literals.TRIGGER__VALUE,
+					'A simple communication should not specify a value attribute',
+					RoboChartPackage.Literals.COMMUNICATION__VALUE,
 					'NoValueForSimpleTriggers'
 				)							
 			}
 		}
 		/* Tg5 */
-		if ((t._type === TriggerType.INPUT || t._type === TriggerType.OUTPUT || t._type === TriggerType.SYNC) &&
+		if ((t._type === CommunicationType.INPUT || t._type === CommunicationType.OUTPUT || t._type === CommunicationType.SYNC) &&
 			t.event.type === null) {
 			error(
-				'An input, output or sync trigger must refer to a typed event. See ' + t.event.name,
-				RoboChartPackage.Literals.TRIGGER__EVENT,
+				'An input, output or sync communication must refer to a typed event. See ' + t.event.name,
+				RoboChartPackage.Literals.COMMUNICATION__EVENT,
 				'TypedEventRequired'
 			)
 		}
 		/* Tg2 */
-		if ((t._type === TriggerType.SIMPLE) && t.event.type !== null) {
+		if ((t._type === CommunicationType.SIMPLE) && t.event.type !== null) {
 			error(
-				'A simple trigger must refer to an untyped event. See ' + t.event.name,
-				RoboChartPackage.Literals.TRIGGER__EVENT,
+				'A simple communication must refer to an untyped event. See ' + t.event.name,
+				RoboChartPackage.Literals.COMMUNICATION__EVENT,
 				'UntypedEventRequired'
 			)
 		}
 		/* Tg3 */
-		if (t._type === TriggerType.INPUT && (t.parameter === null || t.value !== null)) {
+		if (t._type === CommunicationType.INPUT && (t.parameter === null || t.value !== null)) {
 			error(
-				'An input trigger must have a parameter, not a value',
-				RoboChartPackage.Literals.TRIGGER__EVENT,
+				'An input communication must have a parameter, not a value',
+				RoboChartPackage.Literals.COMMUNICATION__EVENT,
 				'InputParameterError'
 			)
 		}
 		/* Tg4 */
-		if (t._type === TriggerType.OUTPUT && (t.parameter !== null || t.value === null)) {
+		if (t._type === CommunicationType.OUTPUT && (t.parameter !== null || t.value === null)) {
 			error(
-				'An output trigger must have a value, not a parameter',
-				RoboChartPackage.Literals.TRIGGER__EVENT,
+				'An output communication must have a value, not a parameter',
+				RoboChartPackage.Literals.COMMUNICATION__EVENT,
 				'OutputParameterError'
 			)
 		}
 		/* Tg4 */
-		if (t._type === TriggerType.SYNC && (t.parameter !== null || t.value === null)) {
+		if (t._type === CommunicationType.SYNC && (t.parameter !== null || t.value === null)) {
 			error(
-				'An synchronisation trigger must have a value, not a parameter',
-				RoboChartPackage.Literals.TRIGGER__EVENT,
+				'An synchronisation communication must have a value, not a parameter',
+				RoboChartPackage.Literals.COMMUNICATION__EVENT,
 				'SyncParameterError'
 			)
 		}
 
-		if (t._type === TriggerType.INPUT) {
+		if (t._type === CommunicationType.INPUT) {
 			val t1 = t.parameter.type
 			val t2 = t.event.type
 			if (!typeCompatible(t1, t2)) {
 				error(
 					'Event ' + t.event.name + ' expects type ' + t2.printType + ', but input parameter has type ' +
 						t1.printType,
-					RoboChartPackage.Literals.TRIGGER__PARAMETER,
-					'InputTriggerTypeError'
+					RoboChartPackage.Literals.COMMUNICATION__PARAMETER,
+					'InputCommunicationTypeError'
 				)
 			}
-		} else if (t._type === TriggerType.OUTPUT) {
+		} else if (t._type === CommunicationType.OUTPUT) {
 			val t1 = t.value.typeFor
 			val t2 = t.event.type
 			if (!typeCompatible(t1, t2)) {
 				error(
 					'Event ' + t.event.name + ' expects type ' + t2.printType + ', but output value has type ' +
 						t1.printType,
-					RoboChartPackage.Literals.TRIGGER__VALUE,
-					'OutputTriggerTypeError'
+					RoboChartPackage.Literals.COMMUNICATION__VALUE,
+					'OutputCommunicationTypeError'
 				)
 			}
-		} else if (t._type === TriggerType.SYNC) {
+		} else if (t._type === CommunicationType.SYNC) {
 			val t1 = t.value.typeFor
 			val t2 = t.event.type
 			if (!typeCompatible(t1, t2)) {
 				error(
 					'Event ' + t.event.name + ' expects type ' + t2.printType +
 						', but synchronisation value has type ' + t1.printType,
-					RoboChartPackage.Literals.TRIGGER__VALUE,
-					'SyncTriggerTypeError'
+					RoboChartPackage.Literals.COMMUNICATION__VALUE,
+					'SyncCommunicationTypeError'
 				)
 			}
-		} else if (t._type === TriggerType.SIMPLE) {
+		} else if (t._type === CommunicationType.SIMPLE) {
 			if (t.event.type !== null) {
 				error(
 					'Event ' + t.event.name + ' expects a value of type ' + t.event.type.printType,
-					RoboChartPackage.Literals.TRIGGER__EVENT,
-					'SimpleTriggerTypeError'
+					RoboChartPackage.Literals.COMMUNICATION__EVENT,
+					'SimpleCommunicationTypeError'
 				)
 			}
 		}
@@ -2238,9 +2234,9 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 
 		for (t : nc.transitions) {
 			// need to check trigger and action of each transition, as both may contain a communication
-			if (t.trigger !== null && t.trigger.get_type === TriggerType.OUTPUT)
+			if (t.trigger !== null && t.trigger.get_type === CommunicationType.OUTPUT)
 				outputs.add(t.trigger.event)
-			if (t.trigger !== null && t.trigger.get_type === TriggerType.SYNC)
+			if (t.trigger !== null && t.trigger.get_type === CommunicationType.SYNC)
 				outputs.add(t.trigger.event) // c.x is an output
 				// simple event in trigger is always an input
 			if(t.action !== null) outputs.addAll(statementOutputSet(t.action))
@@ -2265,12 +2261,12 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		var outputs = new HashSet<Event>()
 
 		if (s instanceof SendEvent) {
-			if (s.trigger !== null && s.trigger.get_type === TriggerType.OUTPUT)
+			if (s.trigger !== null && s.trigger.get_type === CommunicationType.OUTPUT)
 				outputs.add(s.trigger.event)
-			if (s.trigger !== null && s.trigger.get_type === TriggerType.SYNC)
+			if (s.trigger !== null && s.trigger.get_type === CommunicationType.SYNC)
 				outputs.add(s.trigger.event) // c.x is an output
 				// simple event in statement is always an output
-			if (s.trigger !== null && s.trigger.get_type === TriggerType.SIMPLE)
+			if (s.trigger !== null && s.trigger.get_type === CommunicationType.SIMPLE)
 				outputs.add(s.trigger.event)
 		} else if (s instanceof SeqStatement) {
 			for (s2 : s.statements) {
@@ -2289,10 +2285,10 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 
 		for (t : nc.transitions) {
 			// need to check trigger and action of each transition, as both may contain a communication
-			if (t.trigger !== null && t.trigger.get_type === TriggerType.INPUT)
+			if (t.trigger !== null && t.trigger.get_type === CommunicationType.INPUT)
 				inputs.add(t.trigger.event)
 			// simple event in trigger is always an input
-			if (t.trigger !== null && t.trigger.get_type === TriggerType.SIMPLE)
+			if (t.trigger !== null && t.trigger.get_type === CommunicationType.SIMPLE)
 				inputs.add(t.trigger.event)
 			if(t.action !== null) inputs.addAll(statementInputSet(t.action))
 		}
@@ -2317,7 +2313,7 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		var inputs = new HashSet<Event>()
 
 		if (s instanceof SendEvent) {
-			if (s.trigger !== null && s.trigger.get_type === TriggerType.INPUT)
+			if (s.trigger !== null && s.trigger.get_type === CommunicationType.INPUT)
 				inputs.add(s.trigger.event)
 		} else if (s instanceof SeqStatement) {
 			for (s2 : s.statements) {
@@ -2470,7 +2466,7 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	@Check
 	def checkTriggersAreInputs(Transition t) {
 		if (t.trigger !== null) {
-			if (t.trigger.get_type === TriggerType.OUTPUT || t.trigger.get_type === TriggerType.SYNC) {
+			if (t.trigger.get_type === CommunicationType.OUTPUT || t.trigger.get_type === CommunicationType.SYNC) {
 				error(
 					"Only simple or input communications can be used as transition triggers",
 					RoboChartPackage.Literals.TRANSITION__TRIGGER

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -996,14 +996,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 				/* C4 */
 				// In the new compositional semantics this restriction is no longer required,
 				// as instead, C4 only applies at the level of a controller.
-//				val rOps = getROps(s)
-//				if (!pOps.containsAll(rOps)) {
-//					error(
-//						c.name + ' does not provide all operations required by ' + getName(s),
-//						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
-//						'ControllerProvidesAllOps'
-//					)
-//				}
+				val rOps = getROps(s)
+				if (!pOps.containsAll(rOps)) {
+					error(
+						c.name + ' does not provide all operations required by ' + getName(s),
+						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
+						'ControllerProvidesAllOps'
+					)
+				}
 				/* STM9 */
 				val levents = new HashSet<Event>
 				levents.addAll(c.events)
@@ -1100,14 +1100,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 					)
 				}
 				/* C4 */
-//				val rOps = getROps(s)
-//				if (!pOps.containsAll(rOps)) {
-//					error(
-//						c.name + ' in the context of the controller ' + parent.name + ' does not provide all operations required by ' + getName(s),
-//						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
-//						'ControllerProvidesAllOps'
-//					)
-//				}			
+				val rOps = getROps(s)
+				if (!pOps.containsAll(rOps)) {
+					error(
+						c.name + ' in the context of the controller ' + parent.name + ' does not provide all operations required by ' + getName(s),
+						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
+						'ControllerProvidesAllOps'
+					)
+				}			
 			}
 		}
 	}

--- a/upload.sh
+++ b/upload.sh
@@ -5,15 +5,27 @@ url=ahm504@sftp.york.ac.uk
 file=$(ls $dir/features | grep -m 1 jar)
 version=${file#*_}
 version=${version%.jar}
+
+# Use the branch name to choose the name of the branch. This assumes
+# no branch of name 'update' will ever be used.
+if [[ $WERCKER_GIT_BRANCH = master ]];
+then
+  update=update
+else
+  update=$WERCKER_GIT_BRANCH
+fi
+
 if [[ $version = *[!\ ]* ]]; 
 then 
   echo "Current version:" $version;
+  echo "Branch:" $WERCKER_GIT_BRANCH;
+  dest=${update}_${version}
+  echo "Target dir:" $dest;
   rm -rf tmp
   mkdir tmp && cd tmp
-  dest=update_$version
   mkdir $dest
   cp -r ../$dir/* $dest
-  ln -s $dest update
+  ln -s $dest $update
   rsync -a -e "ssh" -rtzh . $url:$remote
   exit $?;
 else


### PR DESCRIPTION
This pull request reflects the changes required in the textual language and the validator in light of the changes to the RoboChart metamodel in commit [deb7cfed](https://github.com/robo-star/circus.robocalc.robochart.parent/commit/deb7cfed207dcb5a62b34e0b46311250d1f62cd2) of the `circus.robocalc.robochart.parent` repository.

There is a **breaking** change in the RoboChart Textual language (.rct) in that the keyword **trigger** is now optional. It is only used if there is an actual **trigger** associated with the transition. The following example now flags up an error on the fourth line:

```
transition t1 {
	from From
	to j0
	trigger
	condition l == Loc::left
	action move( lv , Angle::Right)
}
```
To rectify such issues, it is possible to use Find/Replace of Eclipse over a whole workspace/project to quickly update one or more examples by proceeding as follows:

1. Click on `Search` > `File`.
2. Use the following regular expression: `trigger\s*\n*(\<\{|\}|condition|#|action)`
3. Select `Regular expression`
4. Select the appropriate Scope (eg. `Workspace`)
5. Click on `Replace`
6. Type `$1` in the input box labelled `With:`, so that the match `(...)` in the regular expression can be substituted in place.

Alternatively the traditional `Find/Replace` dialog can be used to perform the same on a file-by-file basis.

If you hit a problem with a particular example, or would like help, please let me know.